### PR TITLE
Remove dependency on `jq`, use plain `python3` instead

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+pyjq() {
+    python3 -c "import json, sys; print(json.load(sys.stdin)${1})"
+}
+
 curl -# https://raw.githubusercontent.com/rust-lang/rust/master/src/rustdoc-json-types/lib.rs | sed 's/rustc_data_structures::fx::/std::collections::/g' | sed 's/FxHashMap/HashMap/g' > src/lib.rs
 
 curl -# https://raw.githubusercontent.com/rust-lang/rust/master/src/rustdoc-json-types/tests.rs > src/tests.rs
 
-curl -# "https://api.github.com/repos/rust-lang/rust/commits?path=src/rustdoc-json-types/lib.rs"  | jq -r ".[0].sha" > COMMIT.txt
+curl -# "https://api.github.com/repos/rust-lang/rust/commits?path=src/rustdoc-json-types/lib.rs" | pyjq '[0]["sha"]' > COMMIT.txt


### PR DESCRIPTION
This change might seem silly, but if you have a new computer and have
not had time to install `jq` yet, the dependency on `jq` is a bit of an
annoyance. `python3` is much more likely to be installed already.