### PR TITLE
update.sh: Make user, repo, and branch easy to change

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -4,8 +4,12 @@ pyjq() {
     python3 -c "import json, sys; print(json.load(sys.stdin)${1})"
 }
 
-curl -# https://raw.githubusercontent.com/rust-lang/rust/master/src/rustdoc-json-types/lib.rs | sed 's/rustc_data_structures::fx::/std::collections::/g' | sed 's/FxHashMap/HashMap/g' > src/lib.rs
+user="rust-lang"
+repo="rust"
+branch="master"
 
-curl -# https://raw.githubusercontent.com/rust-lang/rust/master/src/rustdoc-json-types/tests.rs > src/tests.rs
+curl -# https://raw.githubusercontent.com/${user}/${repo}/${branch}/src/rustdoc-json-types/lib.rs | sed 's/rustc_data_structures::fx::/std::collections::/g' | sed 's/FxHashMap/HashMap/g' > src/lib.rs
 
-curl -# "https://api.github.com/repos/rust-lang/rust/commits?path=src/rustdoc-json-types/lib.rs" | pyjq '[0]["sha"]' > COMMIT.txt
+curl -# https://raw.githubusercontent.com/${user}/${repo}/${branch}/src/rustdoc-json-types/tests.rs > src/tests.rs
+
+curl -# "https://api.github.com/repos/${user}/${repo}/commits?sha=${branch}&path=src/rustdoc-json-types/lib.rs" | pyjq '[0]["sha"]' > COMMIT.txt


### PR DESCRIPTION
This makes it easy for me to try out e.g. https://github.com/rust-lang/rust/pull/99787 by temporarily doing the following change in the script and then run it:

```diff
index 5437494..ba0d8c6 100755
--- a/update.sh
+++ b/update.sh
@@ -4,9 +4,9 @@ pyjq() {
     python3 -c "import json, sys; print(json.load(sys.stdin)${1})"
 }
 
-user="rust-lang"
+user="aDotInTheVoid"
 repo="rust"
-branch="master"
+branch="rdj-dyn"
 
 curl -# https://raw.githubusercontent.com/${user}/${repo}/${branch}/src/rustdoc-json-types/lib.rs | sed 's/rustc_data_structures::fx::/std::collections::/g' | sed 's/FxHashMap/HashMap/g' > src/lib.rs
```

IMHO it would be overkill (and more complicated to use) if we made these changeable by script args ($2 $3 $4) instead, so I prefer this.