### PR TITLE
Speed up compilation by 23%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/rust-lang/rustdoc-types"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version="1", features=["derive"]}
+serde = {version="1"}
+serde_derive = {version="1"}
 rustc-hash = {version="2", optional=true}
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 
 #[cfg(feature = "rustc-hash")]
 use rustc_hash::FxHashMap as HashMap;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 
 /// The version of JSON output that this crate represents.


### PR DESCRIPTION
Before this commit, serde_derive is built before serde. But serde does not depend on serde_derive, so that is not needed. Instead, build serde and serde_derive in parallel. That speeds up compilation by 23%.

Before:

    $ hyperfine --prepare 'cargo clean' 'cargo build'
    Benchmark 1: cargo build
      Time (mean ± σ):      4.979 s ±  0.044 s    [User: 4.887 s, System: 0.714 s]
      Range (min … max):    4.915 s …  5.068 s    10 runs

After:

    $ hyperfine --prepare 'cargo clean' 'cargo build'
    Benchmark 1: cargo build
      Time (mean ± σ):      3.821 s ±  0.065 s    [User: 5.083 s, System: 0.740 s]
      Range (min … max):    3.749 s …  3.955 s    10 runs