### PR TITLE
Exclude development scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Types for rustdoc's json output"
 repository = "https://github.com/rust-lang/rustdoc-types"
+include = ["Cargo.toml", "CHANGELOG.md", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "src/**/*.rs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
During a dependency review we noticed that the rustdoc-types crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.