### PR TITLE
lib.rs: fix broken link to FxHashMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ## `rustc-hash`
 //!
 //! We expose a `rustc-hash` feature, disabled by default. This feature switches the
-//! [`std::collections::HashMap`] for [`rustc_hash::FxHashMap`] to improve the performance of said
+//! [`std::collections::HashMap`] for [`rustc_hash::FxHashMap`][2] to improve the performance of said
 //! `HashMap` in specific situations.
 //!
 //! `cargo-semver-checks` for example, saw a [-3% improvement][1] when benchmarking using the


### PR DESCRIPTION
The second mention linked to the crate, the first one previously didn't