### PR TITLE
Lock down CI a little

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
   cargo-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
     - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -22,5 +22,5 @@ jobs:
     - uses: taiki-e/install-action@a37010ded18ff788be4440302bd6830b1ae50d8b # v2.68.25
       with:
         tool: cargo-hack@0.6.43
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - run: cargo hack test --feature-powerset --locked

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
       with:
         toolchain: 1.85.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents:
+    read
+
 jobs:
   cargo-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
   cargo-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
       with:
         toolchain: 1.85.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write     # Required for OIDC token exchange
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: rust-lang/crates-io-auth-action@v1
       id: auth
     - run: cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
     permissions:
       id-token: write     # Required for OIDC token exchange
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-    - uses: rust-lang/crates-io-auth-action@v1
+    - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       id: auth
     - run: cargo publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
       id-token: write     # Required for OIDC token exchange
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: rust-lang/crates-io-auth-action@v1
       id: auth
     - run: cargo publish


### PR DESCRIPTION
Now zizmor isn't unhappy (even if it has lots to say when the level is cranked up):

```
[nix-shell:~/dev/rust/rustdoc-types-contrib]$ zizmor .
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed ./.github/workflows/CI.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
No findings to report. Good job! (6 suppressed)
```