### PR TITLE
add renovate configuration

### DIFF
--- a/.github/workflows/renovate.json5
+++ b/.github/workflows/renovate.json5
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>rust-lang/renovate"],
+   "packageRules": [
+    // Disabling Rust dependencies because we are only interested in GitHub Actions for now.
+    {
+      "enabled": false,
+      "matchCategories": ["rust"]
+    }
+  ]
+}


### PR DESCRIPTION
Discussed in https://github.com/rust-lang/rustdoc-types/pull/66#issuecomment-4758441085
This should only update GitHub Actions once a week. If you prefer monthly updates, let me know. After merging this, we need to enable renovate in the `team` repo.

More info at https://forge.rust-lang.org/infra/docs/renovate.html